### PR TITLE
Add separate folder for plugin/theme development

### DIFF
--- a/.changes/unreleased/Features-20220919-202029.yaml
+++ b/.changes/unreleased/Features-20220919-202029.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Add seperate folder for plugin/theme development
+time: 2022-09-19T20:20:29.913333127Z


### PR DESCRIPTION
If `local` is set to true, create a `plugin` or `theme` folder alongside the `wordpress` folder and mount that in the docker image. If `local` is set to false use the current directory as the root directory for the plugin or theme.